### PR TITLE
Fix multiline shell command running certbot.

### DIFF
--- a/tasks/nginx.yml
+++ b/tasks/nginx.yml
@@ -27,13 +27,13 @@
 # the file, so we don't need to start it here.  This task will only be executed when no SSL cert
 # exists yet (in virtue of "creates:"), so we don't have to worry about the downtime.
 - name: generate SSL certificate with certbot
-  shell: >
+  shell: >-
     systemctl stop nginx &&
     certbot --standalone certonly
-        --domain {{ MATTERMOST_HOSTNAME }}
-        --email {{ MATTERMOST_OPS_EMAIL }}
-        --non-interactive
-        --agree-tos
+    --domain {{ MATTERMOST_HOSTNAME }}
+    --email {{ MATTERMOST_OPS_EMAIL }}
+    --non-interactive
+    --agree-tos
   args:
     creates: "/etc/letsencrypt/live/{{ MATTERMOST_HOSTNAME }}/fullchain.pem"
 


### PR DESCRIPTION
Since the shell command used YAML's "folded" style (indicated by the ">" character), I expected all newline characters to be removed from the string. However, it turns out that newline characters are kept for lines starting with additional indentation.

I'm not sure how this made it into the final version.  I definitely tested this, and it definitely requested a valid certificate.  The only thing I can think of is that I may have adjusted the formatting of the command later, and in the final round of testing the command got skipped because the cert already existed.

I tested the new version by running it with the new domain name, which sucessfully requested a certificate.