### PR TITLE
Renew the cert after stopping nginx.

### DIFF
--- a/tasks/nginx.yml
+++ b/tasks/nginx.yml
@@ -42,7 +42,7 @@
     cron_file: letsencrypt-renew
     user: root
     name: "Renew SSL certificate using the certbot client"
-    job: certbot renew --quiet
+    job: certbot renew --quiet --pre-hook "service nginx stop" --post-hook "service nginx start"
     hour: "*/12"
     minute: 42
 


### PR DESCRIPTION
*Testing instructions*:

1. Run `certbot renew --dry-run` and see that it fails because nginx is running.
1. Run `certbot renew --pre-hook "service nginx stop" --post-hook "service nginx start" --dry-run` and ensure that it works.
1. Run `certbot renew --pre-hook "service nginx stop" --post-hook "service nginx start"` and ensure that it works without actually stopping nginx (because the certs aren't up for renewal).