### PR TITLE
Remove nginx and Certbot setup code.

### DIFF
--- a/tasks/nginx.yml
+++ b/tasks/nginx.yml
@@ -1,68 +1,23 @@
 ---
-- name: open HTTP ports on the firewall
+- name: open HTTPS port on the firewall
   ufw:
     rule: allow
     port: "{{ item }}"
     proto: tcp
   with_items:
-    - 80
     - 443
-
-- name: install nginx apt package
-  apt:
-    name: nginx
-
-- name: add certbot PPA
-  apt_repository:
-    repo: ppa:certbot/certbot
-
-- name: install certbot apt package
-  apt:
-    update_cache: yes
-    name: python-certbot-nginx
-
-# We need to stop nginx before requesting a certificate, so we can use the Certbot standalone
-# server.  Using the nginx plugin of Certbot is difficult, because it would compete with Ansible
-# for the ownership of the nginx site configuration file.  nginx will be restarted at the end of
-# the file, so we don't need to start it here.  This task will only be executed when no SSL cert
-# exists yet (in virtue of "creates:"), so we don't have to worry about the downtime.
-- name: generate SSL certificate with certbot
-  shell: >-
-    systemctl stop nginx &&
-    certbot --standalone certonly
-    --domain {{ MATTERMOST_HOSTNAME }}
-    --email {{ MATTERMOST_OPS_EMAIL }}
-    --non-interactive
-    --agree-tos
-  args:
-    creates: "/etc/letsencrypt/live/{{ MATTERMOST_HOSTNAME }}/fullchain.pem"
-
-- name: set up cron job for certificate renewal
-  cron:
-    cron_file: letsencrypt-renew
-    user: root
-    name: "Renew SSL certificate using the certbot client"
-    job: certbot renew --quiet --pre-hook "service nginx stop" --post-hook "service nginx start"
-    hour: "*/12"
-    minute: 42
 
 - name: copy nginx site configuration
   template:
     src: mattermost-nginx.j2
     dest: /etc/nginx/sites-available/mattermost
+  notify:
+    - reload nginx
 
 - name: enable nginx site configuration
   file:
     src: /etc/nginx/sites-available/mattermost
     dest: /etc/nginx/sites-enabled/mattermost
     state: link
-
-- name: disable nginx default site
-  file:
-    path: /etc/nginx/sites-enabled/default
-    state: absent
-
-- name: restart nginx
-  service:
-    name: nginx
-    state: restarted
+  notify:
+    - reload nginx

--- a/templates/mattermost-nginx.j2
+++ b/templates/mattermost-nginx.j2
@@ -5,12 +5,6 @@ upstream backend {
 proxy_cache_path /var/cache/nginx levels=1:2 keys_zone=mattermost_cache:10m max_size=3g inactive=120m use_temp_path=off;
 
 server {
-    listen 80 default_server;
-    server_name {{ MATTERMOST_HOSTNAME }};
-    return 301 https://$server_name$request_uri;
-}
-
-server {
     listen 443;
     server_name {{ MATTERMOST_HOSTNAME }};
 

--- a/templates/mattermost-nginx.j2
+++ b/templates/mattermost-nginx.j2
@@ -11,11 +11,6 @@ server {
     ssl on;
     ssl_certificate /etc/letsencrypt/live/{{ MATTERMOST_HOSTNAME }}/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/{{ MATTERMOST_HOSTNAME }}/privkey.pem;
-    ssl_session_timeout 5m;
-    ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
-    ssl_ciphers 'EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH';
-    ssl_prefer_server_ciphers on;
-    ssl_session_cache shared:SSL:10m;
 
     location ~ /api/v[0-9]+/(users/)?websocket$ {
         proxy_set_header Upgrade $http_upgrade;


### PR DESCRIPTION
Certbot and nginx are now set up in the common-server role.